### PR TITLE
Add possible fix for message order bug

### DIFF
--- a/assets/scripts/messages/ui.js
+++ b/assets/scripts/messages/ui.js
@@ -5,13 +5,14 @@ const getMessageTemplate = require('./../templates/user-message.handlebars')
 const showUsers = require('./../templates/user-name.handlebars')
 const showMessages = require('./../templates/user-message.handlebars')
 const chatScroller = require('../../../lib/chat-scroller.js')
+const sortMessages = require('../../../lib/sort-messages.js')
 
 const goShowChat = () => {
   $('.main-content').html(showChat())
 }
 
 const onIndexSuccess = (data) => {
-  const showMessages = getMessageTemplate({ messages: data.messages, users: data.users })
+  const showMessages = getMessageTemplate({ messages: data.messages.sort(sortMessages), users: data.users })
   $('.main-content').find('#chatbox').html(showMessages)
 
   chatScroller.checkForScroll()

--- a/lib/sort-messages.js
+++ b/lib/sort-messages.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const sortMessages = function (a, b) {
+  return a.createdAt - b.createdAt
+}
+
+module.exports = sortMessages


### PR DESCRIPTION
Sorts messages by createdAt date before displaying them. Will have to
deploy in order to test, since this bug has yet to appear locally